### PR TITLE
Fixed type in replace-error-code-with-exception_after

### DIFF
--- a/simple/php/replace-error-code-with-exception_after.php
+++ b/simple/php/replace-error-code-with-exception_after.php
@@ -4,7 +4,7 @@
  *  can throw an exception of given type.)
  * @throws BalanceException
  */
-function withdraw($amount) throws BalanceException {
+function withdraw($amount) {
   if ($amount > $this->balance) {
     throw new BalanceException();
   }


### PR DESCRIPTION
On my PHP 5.5.21 it's a syntax error. Seems like a typo