### PR TITLE
*Dialog classes must extend Dialog parent class

### DIFF
--- a/patterns/pseudocode/en/factory-method.js
+++ b/patterns/pseudocode/en/factory-method.js
@@ -30,11 +30,11 @@ class Dialog is
 
 // Конкретные фабрики переопределяют фабричный метод и возвращают из него
 // свои собственные продукты.
-class WindowsDialog extends Application is
+class WindowsDialog extends Dialog is
     method createButton() is
         return new WindowsButton()
 
-class WebDialog extends Application is
+class WebDialog extends Dialog is
     method createButton() is
         return new HTMLButton()
 

--- a/patterns/pseudocode/ru/factory-method.js
+++ b/patterns/pseudocode/ru/factory-method.js
@@ -30,11 +30,11 @@ class Dialog is
 
 // Конкретные фабрики переопределяют фабричный метод и возвращают из него
 // свои собственные продукты.
-class WindowsDialog extends Application is
+class WindowsDialog extends Dialog is
     method createButton() is
         return new WindowsButton()
 
-class WebDialog extends Application is
+class WebDialog extends Dialog is
     method createButton() is
         return new HTMLButton()
 


### PR DESCRIPTION
In pseudocode `WebDialog` and `WindowsDialog` classes must extend `Dialog` class, not `Application`.