### PR TITLE
Add C++ refactoring examples (C++23/26)

### DIFF
--- a/simple/cpp/extract-method_after.cpp
+++ b/simple/cpp/extract-method_after.cpp
@@ -10,5 +10,5 @@ std::string getOutstanding() { return "42.00"; }
 
 void printDetails(std::string_view name) {
     printBanner();
-    std::println("{}", formatDetails(name, getOutstanding()));
+    std::print("{}", formatDetails(name, getOutstanding()));
 }

--- a/simple/cpp/extract-method_after.cpp
+++ b/simple/cpp/extract-method_after.cpp
@@ -1,6 +1,6 @@
 #include <print>
-void printBanner(){}
 
+void printBanner(){}
 std::string getOutstanding() { return "42.00"; }
 
 [[nodiscard]] std::string formatDetails(std::string_view name, std::string_view outstanding)

--- a/simple/cpp/extract-method_after.cpp
+++ b/simple/cpp/extract-method_after.cpp
@@ -1,0 +1,14 @@
+#include <print>
+void printBanner(){}
+
+std::string getOutstanding() { return "42.00"; }
+
+[[nodiscard]] std::string formatDetails(std::string_view name, std::string_view outstanding)
+{
+    return std::format("name: {}\namount: {}\n", name, outstanding);
+}
+
+void printDetails(std::string_view name) {
+    printBanner();
+    std::println("{}", formatDetails(name, getOutstanding()));
+}

--- a/simple/cpp/extract-method_before.cpp
+++ b/simple/cpp/extract-method_before.cpp
@@ -6,8 +6,6 @@ std::string getOutstanding() { return "42.00"; }
 
 void printDetails(std::string_view name) {
     printBanner();
-
-    // print details
     std::cout << std::format("name: {}\n", name);
     std::cout << std::format("amount: {}\n",  getOutstanding());
 }

--- a/simple/cpp/extract-method_before.cpp
+++ b/simple/cpp/extract-method_before.cpp
@@ -1,0 +1,12 @@
+#include <iostream>
+#include <format>
+void printBanner(){}
+std::string getOutstanding() { return "42.00"; }
+
+void printDetails(std::string_view name) {
+    printBanner();
+
+    // print details
+    std::cout << std::format("name: {}\n", name);
+    std::cout << std::format("amount: {}\n",  getOutstanding());
+}

--- a/simple/cpp/extract-method_before.cpp
+++ b/simple/cpp/extract-method_before.cpp
@@ -1,5 +1,6 @@
 #include <iostream>
 #include <format>
+
 void printBanner(){}
 std::string getOutstanding() { return "42.00"; }
 

--- a/simple/cpp/extract-method_isolate-switch_after.cpp
+++ b/simple/cpp/extract-method_isolate-switch_after.cpp
@@ -16,11 +16,6 @@ struct CNDiscount {static constexpr double factor{0.9};};
 
 using Discount = std::variant<USDiscount, RUDiscount, CNDiscount>;
 
-template<class... Ts>
-struct overloaded : Ts... {
-    using Ts::operator()...;
-};
-
 //User.h
 struct User
 {

--- a/simple/cpp/extract-method_isolate-switch_after.cpp
+++ b/simple/cpp/extract-method_isolate-switch_after.cpp
@@ -1,0 +1,53 @@
+#include <algorithm>
+#include <variant>
+#include <vector>
+
+
+struct Product
+{
+    double quantity;
+    double price;
+};
+
+struct USDiscount {static constexpr double factor{0.85};};
+struct RUDiscount {static constexpr double factor{0.75};};
+struct CNDiscount {static constexpr double factor{0.9};};
+
+using Discount = std::variant<USDiscount, RUDiscount, CNDiscount>;
+
+
+struct User
+{
+    Discount discount;
+};
+
+template<class... Ts>
+struct overloaded : Ts... {
+    using Ts::operator()...;
+};
+
+class Order
+{
+public:
+    explicit Order(const User& user, std::vector<Product> products)
+        : user_{user}
+        , products_(std::move(products))
+    {}
+
+    [[nodiscard]] double calculateTotal() const
+    {
+        const double total = std::ranges::fold_left(products_, 0.0, [](double acc, const auto& product){return acc + (product.price * product.quantity);});
+        return applyRegionalDiscounts(total);
+    }
+
+    [[nodiscard]] double applyRegionalDiscounts(double total) const
+    {
+        return std::visit([total](const auto& discount) {
+            return total * discount.factor;
+        }, user_.discount);
+    }
+
+private:
+    User user_;
+    std::vector<Product> products_;
+};

--- a/simple/cpp/extract-method_isolate-switch_after.cpp
+++ b/simple/cpp/extract-method_isolate-switch_after.cpp
@@ -2,30 +2,33 @@
 #include <variant>
 #include <vector>
 
-
+//Product.h
 struct Product
 {
     double quantity;
     double price;
 };
 
+//Discounts.h
 struct USDiscount {static constexpr double factor{0.85};};
 struct RUDiscount {static constexpr double factor{0.75};};
 struct CNDiscount {static constexpr double factor{0.9};};
 
 using Discount = std::variant<USDiscount, RUDiscount, CNDiscount>;
 
-
-struct User
-{
-    Discount discount;
-};
-
 template<class... Ts>
 struct overloaded : Ts... {
     using Ts::operator()...;
 };
 
+//User.h
+struct User
+{
+    Discount discount;
+};
+
+
+// Order.h and Order.cpp if separating header from source
 class Order
 {
 public:

--- a/simple/cpp/extract-method_isolate-switch_before.cpp
+++ b/simple/cpp/extract-method_isolate-switch_before.cpp
@@ -1,0 +1,47 @@
+#include <vector>
+
+enum class Country
+{
+    US,
+    RU,
+    CN
+};
+
+struct User
+{
+    Country country;
+};
+
+struct Product
+{
+    double quantity;
+    double price;
+};
+
+class Order
+{
+public:
+    explicit Order(const User& user, std::vector<Product> products)
+        : user_{user}
+        , products_(std::move(products))
+        {}
+    [[nodiscard]] double calculateTotal() const
+    {
+        double total = 0;
+        for (const auto& [quantity, price] : products_)
+        {
+            total += price * quantity;
+        }
+        switch (user_.country)
+        {
+        case Country::US: total *= 0.85; break;
+        case Country::RU: total *= 0.75; break;
+        case Country::CN: total *= 0.9; break;
+        }
+        return total;
+    }
+
+private:
+    User user_;
+    std::vector<Product> products_;
+};

--- a/simple/cpp/substitute-algorithm_after.cpp
+++ b/simple/cpp/substitute-algorithm_after.cpp
@@ -4,10 +4,12 @@
 #include <span>
 #include <array>
 
-std::optional<std::string> FoundPerson(std::span<const std::string> people){
+std::optional<std::string> FoundPerson(std::span<const std::string> people)
+{
     static constexpr std::array<std::string_view, 3> candidates{"Don", "John", "Kent"};
 
-    if (const auto it = std::ranges::find_first_of(people, candidates); it != people.end()) {
+    if (const auto it = std::ranges::find_first_of(people, candidates); it != people.end())
+    {
         return *it;
     }
     return std::nullopt;

--- a/simple/cpp/substitute-algorithm_after.cpp
+++ b/simple/cpp/substitute-algorithm_after.cpp
@@ -1,0 +1,14 @@
+#include <algorithm>
+#include <optional>
+#include <string>
+#include <span>
+#include <array>
+
+std::optional<std::string> FoundPerson(std::span<const std::string> people){
+    static constexpr std::array<std::string_view, 3> candidates{"Don", "John", "Kent"};
+
+    if (const auto it = std::ranges::find_first_of(people, candidates); it != people.end()) {
+        return *it;
+    }
+    return std::nullopt;
+}

--- a/simple/cpp/substitute-algorithm_before.cpp
+++ b/simple/cpp/substitute-algorithm_before.cpp
@@ -1,0 +1,22 @@
+#include <string>
+#include <span>
+
+std::string FoundPerson(std::span<const std::string> people)
+{
+    for (const auto & person : people)
+    {
+        if (person == ("Don"))
+        {
+            return "Don";
+        }
+        if (person == ("John"))
+        {
+            return "John";
+        }
+        if (person == ("Kent"))
+        {
+            return "Kent";
+        }
+    }
+    return "";
+}


### PR DESCRIPTION
### Summary

This PR ports some of the existing examples in Java to C++. I have added before and after examples for the following 3 techniques:

- **Extract Method**
- **Extract Method – Isolate Switch**
- **Substitute Algorithm**

All examples compile when tested with clang trunk and using C++26. The `before` files are a direct, idiomatic C++ translation of the Java originals. The `after` files apply the refactoring and additionally adopt several modern C++ idioms where I felt appropriate.

### Design decisions & deviations from Java originals

I was having trouble porting some of the solutions to C++ since many things that may be considered idiomatic in Java don't necessarily have 1 to 1 mappings in C++. I made the following decisions:

#### Substitute Algorithm
- `before`: raw `if`-chain returning `""` on failure —  true to the Java original
- `after`: replaces the chain with `std::ranges::find_first_of` over a `static constexpr std::array<std::string_view>`, and returns `std::optional<std::string>` instead of an empty string sentinel.
- **Rationale**: empty-string-as-failure has no idiomatic equivalent in modern C++ so I used `std::optional`. I think that using ranges `find_first_of` is really nice since it expresses the algorithm's intent quite clearly.

#### Extract Method – Isolate Switch
- `before`: raw loop + `switch` on an enum, applying a discount factor
- `after`: replaces the `switch` with `std::variant` + `std::visit` over typed discount structs, each holding a `static constexpr double factor`; total is computed via `std::ranges::fold_left`
- **Rationale**: C++ has no pattern matching to the best of my knowledge unless you just use if/else with strings. I therefore decided to use `std::variant` + `std::visit` which also would fit *Replace Conditional with Polymorphism* quite nicely.

#### Extract Method (basic)
- std::print might not work for older versions of C++ and certain compilers. 
- `std::cout << std::format() << std::endl` would work even for older versions of the language and compilers so it might be a better choice. But I decided to go ahead with std::print since the name carries the intent a lot better in my opinion.


### Notes
- Targets C++23/26 (`std::print`, `std::ranges::fold_left`, `std::ranges::find_first_of`, `std::span`)
- Added `[[nodiscard]]` when appropriate even though it adds some "noise". I added it to the signature of all functions that return values since looking at clang tidy complaining about it was stressing me out 😅 


Happy to discuss these design decisions! 😄 
